### PR TITLE
do not hijack process handlers

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 const shm = require('./build/Release/shm.node');
-const nodeCleanup = require('node-cleanup');
 const cluster = require('cluster');
 
 const uint32Max = Math.pow(2,32) - 1;
@@ -21,7 +20,6 @@ const cleanup = function () {
 	} catch(exc) { console.error(exc); }
 };
 process.on('exit', cleanup);
-nodeCleanup(cleanup);
 
 /**
  * Types of shared memory object

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "nan": "^2.13.2",
-    "node-cleanup": "^1.0.1"
+    "nan": "^2.13.2"
   },
   "os": [
     "!win32"


### PR DESCRIPTION
node-cleanup is too opinionated and can cause shared memory handles to orphan. i share memory with a forked process, and this causes that process to not detach and my shared memory space on mac never recovers without a restart