### PR TITLE
Update for node v16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules/
 npm-debug.log
 package-lock.json
 .vscode
+.cache
+compile_commands.json

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 const shm = require('./build/Release/shm.node');
-const cluster = require('cluster');
 
 const uint32Max = Math.pow(2,32) - 1;
 const keyMin = 1;


### PR DESCRIPTION
node v16 [removed the single-argument `node::AtExit`](https://github.com/nodejs/node/pull/35897) function, causing `shm-typed-array` to fail to compile. This PR switches to use `AddEnvironmentCleanupHook` on node v16+.